### PR TITLE
Reverted the Android SDK version to 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'jacoco'
 apply plugin: 'de.undercouch.download'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         // Version code is generated as time since June 1, 2019. These allows for constantly
@@ -22,7 +22,7 @@ android {
 
         applicationId "tech.ula"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode vcode
         versionName "2.7.3"
         


### PR DESCRIPTION
**Note**
Pull requests should follow the git flow described in the [wiki](https://github.com/CypherpunkArmory/UserLAnd/wiki/Git-flow).
To get git history clean and aid in more useful release notes, it is essential to use the `Squash and merge` option when
merging into 'master', and the `Create merge commit` option when merging into 'releases'.

## What changes does this PR introduce?
Enables access to almost-all Android storage again like in Android 9 (R/W for internal memory, and at least Read for the SD Card)

## Any background context you want to provide?
Tested on LG devices G7 ThinQ and G8s.

## Where should the reviewer start?
Just the one file app/build.gradle .

## Has this been manually tested? How?
Compiled offline, installed on the devices, tested successfully for months.

## What value does this provide to our end users?
Enables access to almost-all Android storage again like in Android 9. This fits better to the aim to have a full Linux operating system.

## What GIF best describes this PR or how it makes you feel?
Wow!

